### PR TITLE
Add devedition config for testing the dev edition theme in 3 states (dark, light, and off)

### DIFF
--- a/mozscreenshots/extension/configurations/DevEdition.jsm
+++ b/mozscreenshots/extension/configurations/DevEdition.jsm
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = [ "DevEdition" ];
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/devtools/Console.jsm");
+
+this.DevEdition = {
+  init: function(libDir) {},
+
+  configurations: {
+    devEditionLight: {
+      applyConfig: (deferred) => {
+        Services.prefs.setCharPref("devtools.theme", "light");
+        Services.prefs.setBoolPref("browser.devedition.theme.enabled", true);
+        Services.prefs.setBoolPref("browser.devedition.theme.showCustomizeButton", true);
+        deferred.resolve("devEditionLight");
+      }
+    },
+    devEditionDark: {
+      applyConfig: (deferred) => {
+        Services.prefs.setCharPref("devtools.theme", "dark");
+        Services.prefs.setBoolPref("browser.devedition.theme.enabled", true);
+        Services.prefs.setBoolPref("browser.devedition.theme.showCustomizeButton", true);
+        deferred.resolve("devEditionDark");
+      }
+    },
+    devEditionOff: {
+      applyConfig: (deferred) => {
+        Services.prefs.clearUserPref("devtools.theme");
+        Services.prefs.clearUserPref("browser.devedition.theme.enabled");
+        Services.prefs.clearUserPref("browser.devedition.theme.showCustomizeButton");
+        deferred.resolve("devEditionOff");
+      }
+    },
+  },
+};


### PR DESCRIPTION
See #22.  This adds configurations for checking the dev edition theme. It could be combined with:
1. The existing browser chrome configurations for testing the devedition theme (primary use case).
2. The devtools configurations for testing the toolbox in dark and light themes (will add a third state here of 'off' on the devedition theme that will end up with a third set of light theme screenshots, but that's fine for now).  If we just care about the dark toolbox we could always set that pref via the command line and run the devtools suite alone.
