### PR TITLE
fetch_screenshots: Add a user agent to requests made to Treeherder's API

### DIFF
--- a/mozscreenshots/__init__.py
+++ b/mozscreenshots/__init__.py
@@ -3,3 +3,5 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from runner import *
+
+__version__ = '0.3.1'


### PR DESCRIPTION
In bug 1230222 we're encouraging consumers of Treeherder's API to set a user agent:
https://bugzilla.mozilla.org/show_bug.cgi?id=1230222

Manual checking of the response status code has been replaces with `raise_for_status()`:
http://docs.python-requests.org/en/master/user/quickstart/#response-status-codes

A version number has been added to `__init__.py` for use in the user agent. This duplicates that in `setup.py`, however all the solutions for avoiding this are a bit more involved than makes sense for this PR, so this seems better suited for a later change:
https://packaging.python.org/en/latest/single_source_version/